### PR TITLE
Add animation logic to main screen view

### DIFF
--- a/TransartistryApp/TransartistryApp.xcodeproj/project.pbxproj
+++ b/TransartistryApp/TransartistryApp.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		58AE4A16299A877800755611 /* PhotoPickerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58AE4A15299A877800755611 /* PhotoPickerManager.swift */; };
 		58AE4A18299A88C900755611 /* PhotoPickerParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58AE4A17299A88C900755611 /* PhotoPickerParameters.swift */; };
 		58D7A359299A9FAE0004BB74 /* Distributor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D7A358299A9FAE0004BB74 /* Distributor.swift */; };
+		58E8667D299D3D9D00591CCE /* UIColor+Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E8667C299D3D9D00591CCE /* UIColor+Random.swift */; };
 		58F34D26278228B3004D33AC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F34D25278228B3004D33AC /* AppDelegate.swift */; };
 		58F34D28278228B3004D33AC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F34D27278228B3004D33AC /* SceneDelegate.swift */; };
 		58F34D2F278228B5004D33AC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 58F34D2E278228B5004D33AC /* Assets.xcassets */; };
@@ -131,6 +132,7 @@
 		58AE4A15299A877800755611 /* PhotoPickerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPickerManager.swift; sourceTree = "<group>"; };
 		58AE4A17299A88C900755611 /* PhotoPickerParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPickerParameters.swift; sourceTree = "<group>"; };
 		58D7A358299A9FAE0004BB74 /* Distributor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Distributor.swift; sourceTree = "<group>"; };
+		58E8667C299D3D9D00591CCE /* UIColor+Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Random.swift"; sourceTree = "<group>"; };
 		58F34D22278228B3004D33AC /* TransartistryApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TransartistryApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		58F34D25278228B3004D33AC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		58F34D27278228B3004D33AC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -430,6 +432,7 @@
 			isa = PBXGroup;
 			children = (
 				5848C881298884510055AD99 /* UIColor+Palette.swift */,
+				58E8667C299D3D9D00591CCE /* UIColor+Random.swift */,
 			);
 			path = UIColor;
 			sourceTree = "<group>";
@@ -890,6 +893,7 @@
 				58AE4A18299A88C900755611 /* PhotoPickerParameters.swift in Sources */,
 				5818BA44298BE6E20080F8EB /* BaseModule.swift in Sources */,
 				58AAD96A2996771A0072B764 /* PhotoDistributor.swift in Sources */,
+				58E8667D299D3D9D00591CCE /* UIColor+Random.swift in Sources */,
 				5848C882298884510055AD99 /* UIColor+Palette.swift in Sources */,
 				5848C872298867860055AD99 /* UIFont+Weights.swift in Sources */,
 				5848C875298869090055AD99 /* NSAttributedString+Extension.swift in Sources */,

--- a/TransartistryApp/TransartistryApp/Extension/UIColor/UIColor+Random.swift
+++ b/TransartistryApp/TransartistryApp/Extension/UIColor/UIColor+Random.swift
@@ -1,0 +1,10 @@
+import UIKit.UIColor
+
+extension UIColor {
+    static func random() -> UIColor {
+        return UIColor(red: .random(in: 0...1),
+                       green: .random(in: 0...1),
+                       blue: .random(in: 0...1),
+                       alpha: 1.0)
+    }
+}

--- a/TransartistryApp/TransartistryApp/PresentationLayer/Modules/MainScreenModule/View/MainScreenView.swift
+++ b/TransartistryApp/TransartistryApp/PresentationLayer/Modules/MainScreenModule/View/MainScreenView.swift
@@ -54,7 +54,7 @@ final class MainScreenView: BaseView {
         
         backgroundColor = .whiteLM
         
-        logoImageView.tintColor = .blackLM
+        logoImageView.tintColor = Constants.logoImageViewTintColor
         logoImageView.contentMode = .scaleAspectFit
         
         containerView.axis = .vertical
@@ -90,6 +90,8 @@ private extension Constants {
     static let logoImageViewHeightMultiplier: CGFloat = 0.5
     static let appNameLabelHeightMultiplier: CGFloat = 0.2
     static let actionButtonFontSize: CGFloat = 16
+    
+    static let logoImageViewTintColor: UIColor = .blackLM
 }
 
 extension Reactive where Base: MainScreenView {
@@ -99,5 +101,26 @@ extension Reactive where Base: MainScreenView {
     
     var imagePickerButtonTap: ControlEvent<Void> {
         base.imagePickerButtonView.wrappedView.rx.tap
+    }
+}
+
+extension MainScreenView {
+    
+    func animate(with shouldStartAnimation: Bool) {
+        shouldStartAnimation
+            ? startAnimation()
+            : stopAnimation()
+    }
+    
+    private func startAnimation() {
+        UIView.animate(withDuration: 1, delay: .zero, options: [.autoreverse, .repeat, .curveEaseIn]) { [weak self] in
+            self?.logoImageView.tintColor = .random()
+        }
+    }
+    
+    private func stopAnimation() {
+        UIView.animate(withDuration: 1, delay: .zero, options: [.beginFromCurrentState]) { [weak self] in
+            self?.logoImageView.tintColor = Constants.logoImageViewTintColor
+        }
     }
 }


### PR DESCRIPTION
## Добавление анимации на главный экран – MainScreenView

- Добавил анимацию мигания логотипа на главном экране. Активация анимации будет происходить по нажатию на одну из кнопок выбора фотографии, а окончание анимации - после того, как фото с камеры или из библиотеки изображений будет получено во вьюмодели и готово будет к передаче далее на последующие экраны. Использовал стандартную анимацию через UIView.animate(...) с флагами(опциями) .autoreverse и .repeat для зацикливания анимации, окончание анимации реализую через присваивание нового значения свойству анимируемого экземпляра(в данном случае UIImageView и свойство tintColor), завершение основной анимации делаю анимированным и не резким за счет флага(опции) .beginFromCurrentState.
### Результат
- В видео ниже кнопку "Сфотографировать" для демонстрации результата временно переиначил на старт анимации, а кнопку "Выбрать фото" для окончания анимации

https://user-images.githubusercontent.com/82877037/219095986-73e0016e-9825-43a9-a438-6176f292ffcf.MP4