### PR TITLE
Fix layout on MainScreenView

### DIFF
--- a/TransartistryApp/TransartistryApp.xcodeproj/project.pbxproj
+++ b/TransartistryApp/TransartistryApp.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		58F34D3D278228B5004D33AC /* TransartistryAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F34D3C278228B5004D33AC /* TransartistryAppTests.swift */; };
 		58F34D47278228B5004D33AC /* TransartistryAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F34D46278228B5004D33AC /* TransartistryAppUITests.swift */; };
 		58F34D49278228B5004D33AC /* TransartistryAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F34D48278228B5004D33AC /* TransartistryAppUITestsLaunchTests.swift */; };
+		58FC57AA29A410A0000DB358 /* UIViewController+Orientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58FC57A929A410A0000DB358 /* UIViewController+Orientation.swift */; };
 		7FBCC8FD14717C82F56C81E1 /* Pods_TransartistryAppTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9E0F1FA753D75C9F8B1D39D /* Pods_TransartistryAppTests.framework */; };
 		82BB20C6C1A5656B30A46120 /* Pods_TransartistryApp_TransartistryAppUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 343ECC07083EE0830FA64F75 /* Pods_TransartistryApp_TransartistryAppUITests.framework */; };
 		F27EB0EAFE8BE9D9B0C7C3C3 /* Pods_TransartistryApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A43BD0876E76B22A813A0F7C /* Pods_TransartistryApp.framework */; };
@@ -162,6 +163,7 @@
 		58F34D42278228B5004D33AC /* TransartistryAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TransartistryAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		58F34D46278228B5004D33AC /* TransartistryAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransartistryAppUITests.swift; sourceTree = "<group>"; };
 		58F34D48278228B5004D33AC /* TransartistryAppUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransartistryAppUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		58FC57A929A410A0000DB358 /* UIViewController+Orientation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Orientation.swift"; sourceTree = "<group>"; };
 		7CCF561616755555CEA0730B /* Pods-TransartistryApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TransartistryApp.debug.xcconfig"; path = "Target Support Files/Pods-TransartistryApp/Pods-TransartistryApp.debug.xcconfig"; sourceTree = "<group>"; };
 		A43BD0876E76B22A813A0F7C /* Pods_TransartistryApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TransartistryApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9E0F1FA753D75C9F8B1D39D /* Pods_TransartistryAppTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TransartistryAppTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -564,6 +566,7 @@
 			isa = PBXGroup;
 			children = (
 				58D48719299FF660006908E8 /* UIViewController+Alert.swift */,
+				58FC57A929A410A0000DB358 /* UIViewController+Orientation.swift */,
 			);
 			path = UIViewController;
 			sourceTree = "<group>";
@@ -947,6 +950,7 @@
 				5848C84D29859E780055AD99 /* DisposeBagHolder.swift in Sources */,
 				58AE4A16299A877800755611 /* PhotoPickerManager.swift in Sources */,
 				582B64EB29817DFC004D76EB /* BaseView.swift in Sources */,
+				58FC57AA29A410A0000DB358 /* UIViewController+Orientation.swift in Sources */,
 				58AE4A18299A88C900755611 /* PhotoPickerParameters.swift in Sources */,
 				5818BA44298BE6E20080F8EB /* BaseModule.swift in Sources */,
 				58D48717299EE851006908E8 /* AlertFactory.swift in Sources */,
@@ -1154,8 +1158,7 @@
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Please, allow access to take a photo directly in the App!";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1184,8 +1187,7 @@
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Please, allow access to take a photo directly in the App!";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/TransartistryApp/TransartistryApp/Extension/UIViewController/UIViewController+Orientation.swift
+++ b/TransartistryApp/TransartistryApp/Extension/UIViewController/UIViewController+Orientation.swift
@@ -1,0 +1,9 @@
+import RxSwift
+
+extension UIViewController {
+    var deviceOrientationHandler: Observable<Notification> {
+        NotificationCenter.default.rx
+            .notification(UIDevice.orientationDidChangeNotification)
+            .asObservable()
+    }
+}

--- a/TransartistryApp/TransartistryApp/PresentationLayer/Modules/MainScreenModule/View/MainScreenView.swift
+++ b/TransartistryApp/TransartistryApp/PresentationLayer/Modules/MainScreenModule/View/MainScreenView.swift
@@ -37,15 +37,10 @@ final class MainScreenView: BaseView {
         }
         
         containerView.snp.makeConstraints {
+            $0.top.equalTo(appNameLabel.snp.bottom)
             $0.bottom.equalTo(safeArea).inset(Constants.inset32)
             $0.width.equalToSuperview().multipliedBy(Constants.generalWidthMultiplier)
             $0.centerX.equalToSuperview()
-        }
-        
-        [cameraPickerButtonView, imagePickerButtonView].forEach {
-            $0.snp.makeConstraints {
-                $0.height.equalTo(Constants.defaultButtonHeight48)
-            }
         }
     }
     
@@ -59,6 +54,7 @@ final class MainScreenView: BaseView {
         
         containerView.axis = .vertical
         containerView.spacing = Constants.inset16
+        containerView.distribution = .fillEqually
         
         cameraPickerButtonView.wrappedView.backgroundColor = .whiteLM
         cameraPickerButtonView.wrappedView.setTitleColor(.blackLM, for: .normal)
@@ -86,8 +82,24 @@ final class MainScreenView: BaseView {
     }
     
     fileprivate func configureButtonsAvailability(with isEnabled: Bool) {
-        cameraPickerButtonView.wrappedView.isEnabled = isEnabled
-        imagePickerButtonView.wrappedView.isEnabled = isEnabled
+        [cameraPickerButtonView.wrappedView, imagePickerButtonView.wrappedView].forEach {
+            $0.isEnabled = isEnabled
+        }
+    }
+    
+    fileprivate func handleOrientationChanges() {
+        
+        let deviceOrientation = UIDevice.current.orientation
+        
+        guard deviceOrientation.isValidInterfaceOrientation else {
+            return
+        }
+        
+        if deviceOrientation == .landscapeLeft || deviceOrientation == .landscapeRight {
+            containerView.axis = .horizontal
+        } else {
+            containerView.axis = .vertical
+        }
     }
 }
 
@@ -118,6 +130,12 @@ extension Reactive where Base: MainScreenView {
     var isButtonInteractionEnabled: Binder<Bool> {
         Binder(self.base) { base, isEnabled in
             base.configureButtonsAvailability(with: isEnabled)
+        }
+    }
+    
+    var orientationHandler: Binder<Void> {
+        Binder(self.base) { base, _ in
+            base.handleOrientationChanges()
         }
     }
 }

--- a/TransartistryApp/TransartistryApp/PresentationLayer/Modules/MainScreenModule/View/MainScreenViewController.swift
+++ b/TransartistryApp/TransartistryApp/PresentationLayer/Modules/MainScreenModule/View/MainScreenViewController.swift
@@ -55,5 +55,11 @@ final class MainScreenViewController<VM: MainScreenViewModelOutlets>: BaseCustom
         viewModel.alertPresentationDriver
             .drive(self.rx.alertPresentation)
             .disposed(by: disposeBag)
+        
+        deviceOrientationHandler
+            .observe(on: MainScheduler.instance)
+            .map { _ in Void() }
+            .subscribe(customView.rx.orientationHandler)
+            .disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
## Корректировка лэйаута на MainScreenView

- В ландшафтном режиме кнопки "Сфотографировать" и "Выбрать фото" на главном экране **MainScreenView** налезали на другие UI-элементы экрана(результат "до", видео 1). Исправил это установкой верхнего констрейнта для стэкВью, в котором находятся кнопки, и привязкой логики по отображению к _UIDevice.current.orientation_, а именно изменяю свойство `.axis` класса **UIStackView** для того, чтобы разместить кнопки по горизонтали в ландшафтном режиме(чтоб не ужимались) и по вертикали в портретном.
- Для получения информации об изменении ориентации не использовал приведенные ниже методы из-за следующей ситуации: устройство в ландшафтном режиме -> нажата кнопка "Сфотографировать" -> открывается модуль камеры **UIImagePickerController** -> переворачиваем устройство и делаем фотографию -> Модуль закрывается, возвращаемся на **MainScreenVC** и **MainScreenView**. Приведенные ниже методы вызываются только после закрытия модуля камеры и появления **MainScreenVC**, из-за чего можно было наблюдать ситуацию, что в портретном режиме кнопки располагались горизонтально, а не вертикально, но на глазах меняли свое расположение, потому что прописанная операция по смене оси выполнялась в приведенных ниже методах. 
  -  `traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?)`
  - `willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator)`
  - `viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator)`
 - В случае с реактивным получением уведомления _UIDevice.orientationDidChangeNotification_ об измене ориентации удалось обойти использование методов выше и устранить некорректное отображение кнопок после закрытия модуля камеры. Свойство рассылает уведомление всякий раз, как меняется ориентация самого устройства, нет зависимости ни от жизненного цикла наблюдаемого пользователем VC, ни от методов протокола **UITraitEnvironment** и **UIContentContainer**.
 - В прописанных условиях по ориентациям(`.landscapeLeft` || `.landscapeRight`) в **MainScreenView** есть проверка `.isValidInterfaceOrientation` – это необходимо для устранения таких ориентаций, как `.faceUp`, `.faceDown`, `.unknown`. Валидные значения: `landscapeLeft`, `landscapeRight`, `portrait`, `portraitUpsideDown` – **UIDeviceOrientation**

### Результат
#### До исправления:
https://user-images.githubusercontent.com/82877037/220204931-78f07b0a-00d3-4c9d-a0ff-0d8f5230eb6f.MP4

#### После исправления:
https://user-images.githubusercontent.com/82877037/220204968-076e8ea0-041e-4c21-a581-9232ab90cf6d.MP4